### PR TITLE
Improve learn editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,19 @@ Take the first arg as the learning text and inserts into learning table
 
 - se (short for search)
 
+- editl (short for edit)
+
+Find and edit a learning by id. Opens in default text editor.
+
 Selects learning column from all records from the learning table
 
 - del (short for delete)
 
 Deletes last item from table
+
+- delid (short for delete by id)
+
+Deletes a specific id from the learning table
 
 - sef (short for search fzf)
 

--- a/autoload/zsh-learn-DeleteId
+++ b/autoload/zsh-learn-DeleteId
@@ -1,0 +1,11 @@
+# -*- mode: sh -*-
+# vim: set ft=sh:
+function zsh-learn-DeleteId(){
+    if [[ -z $1 ]]; then
+        echo "Usage: zsh-learn-DeleteId <id>"
+        return 1
+    fi
+    echo "DELETE FROM $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME WHERE id = "$1";" | ${=ZPWR_LEARN_COMMAND}
+}
+
+zsh-learn-DeleteId "$@"

--- a/autoload/zsh-learn-Editl
+++ b/autoload/zsh-learn-Editl
@@ -6,12 +6,12 @@ function zsh-learn-Editl(){
         return 1
     fi
 
-    content=$(echo "SELECT learning FROM $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME WHERE id = $1;" | ${=ZPWR_LEARN_COMMAND} --silent)
+    content=$(echo "SELECT learning FROM $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME WHERE id = $1;" | ${=ZPWR_LEARN_COMMAND} | tail +2)
 
-    filename="/tmp/edit-note"
+    filename="${TMPDIR:-/tmp}/edit-learning"
     touch $filename
     echo $content >> $filename
-    $EDITOR $filename
+    ${=EDITOR} $filename
     learning=$(cat $filename)
     rm $filename
 

--- a/autoload/zsh-learn-Editl
+++ b/autoload/zsh-learn-Editl
@@ -1,0 +1,26 @@
+# -*- mode: sh -*-
+# vim: set ft=sh:
+function zsh-learn-Editl(){
+    if [[ -z $1 ]]; then
+        echo "Usage: zsh-learn-Edit <id>"
+        return 1
+    fi
+
+    content=$(echo "SELECT learning FROM $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME WHERE id = $1;" | ${=ZPWR_LEARN_COMMAND} --silent)
+
+    filename="/tmp/edit-note"
+    touch $filename
+    echo $content >> $filename
+    $EDITOR $filename
+    learning=$(cat $filename)
+    rm $filename
+
+    if [[ -z $learning ]]; then
+        echo "Content cannot be empty"
+        return 1
+    fi
+
+    echo "UPDATE $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME SET learning='"$learning"' WHERE id = $1;" | ${=ZPWR_LEARN_COMMAND}
+}
+
+zsh-learn-Editl "$@"

--- a/autoload/zsh-learn-Savel
+++ b/autoload/zsh-learn-Savel
@@ -12,9 +12,9 @@ function zsh-learn-Savel(){
         case $opt in
 
         e)
-            filename="/tmp/edit-learning"
+            filename="${TMPDIR:-/tmp}/edit-learning"
             touch $filename
-            $EDITOR $filename
+            ${=EDITOR} $filename
             learning=$(cat $filename)
             rm $filename
             ;;

--- a/autoload/zsh-learn-Savel
+++ b/autoload/zsh-learn-Savel
@@ -1,19 +1,42 @@
 # -*- mode: sh -*-
 # vim: set ft=sh:
 function zsh-learn-Savel(){
-
-    if [[ -z "$1" ]]; then
-        echo "usage: zsh-learn-Savel <learning> [<category>]" >&2
-        return 1
-    fi
+    function usage() {
+        echo "Usage: zsh-learn-Savel [options] <learning>\nOptions:\n -e    Edit learning in default editor\n -c    Set a custom category"
+    }
 
     local category learning
-
     category="programming"
-    learning="$(printf -- '%s' "$1" | sed 's@^[[:space:]]*@@;s@[[:space:]]*$@@')"
 
-    if [[ -n "$2" ]]; then
-        category="$2"
+    while getopts "ec:" opt; do
+        case $opt in
+
+        e)
+            filename="/tmp/edit-learning"
+            touch $filename
+            $EDITOR $filename
+            learning=$(cat $filename)
+            rm $filename
+            ;;
+        c)
+            category=$OPTARG
+            ;;
+        *)
+            printf "\n  Option does not exist : $OPTARG\n"
+            usage
+            return 1
+            ;;
+        esac
+    done
+    shift $(($OPTIND-1))
+
+    if [[ -z $learning ]]; then
+        learning="$(printf -- '%s' "$1" | sed 's@^[[:space:]]*@@;s@[[:space:]]*$@@')"
+    fi
+
+    if [[ -z $learning ]]; then
+        usage
+        return 1
     fi
 
     echo "insert into $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME (category, learning, dateAdded) values ('"$category"', '""$learning""', now())" | ${=ZPWR_LEARN_COMMAND} 2>> "$ZPWR_LOGFILE"

--- a/zsh-learn.plugin.zsh
+++ b/zsh-learn.plugin.zsh
@@ -63,14 +63,18 @@ alias rsql='noglob zsh-learn-Redosql'
 alias see='noglob zsh-learn-Searchle'
 alias seee='noglob zsh-learn-Searchlee'
 alias se='noglob zsh-learn-Searchl'
+alias editl='noglob zsh-learn-Editl'
+alias delid='noglob zsh-learn-DeleteId'
 
 if (( ${+ZPWR_VERBS} )); then
 
     ZPWR_VERBS[learn]='zsh-learn-Savel=save learning to $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME'
     ZPWR_VERBS[learndel]='del=delete learning from $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME'
+    ZPWR_VERBS[editl]='zsh-learn-Editl=Edit learning by id from $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME'
     ZPWR_VERBS[del]='del=delete learning from $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME'
     ZPWR_VERBS[delete]='del=delete learning from $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME'
     ZPWR_VERBS[learndelete]='del=delete save learning from $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME'
+    ZPWR_VERBS[delid]='zsh-learn-DeleteId=delete learning by id from $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME'
     ZPWR_VERBS[createlearningcollection]='zsh-learn-CreateLearningCollection=create $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME with mysql -u root'
     ZPWR_VERBS[droplearningcollection]='zsh-learn-DropLearningCollection=drop $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME with mysql -u root'
     ZPWR_VERBS[learnsearch]='se=search for learning in $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME'


### PR DESCRIPTION
This is the proposed change I inquired about over Slack, plus a couple other new functions. I think the proposed changes here are straight forward, but if any part of it is confusing I can move that to a separate issue to discuss.

Changes in this PR:

- Add editor option to `zsh-learn-Savel`. If you have a multi-line note, you can now call `le -e` to open the default editor (defined by `$EDITOR`) to enter your learning.
- Add edit function `zsh-learn-Editl` (aliased to `editl`) to edit an existing learning by id. This opens in the default editor too. Similar to `zsh-learn-Redo` without showing the SQL update statement. You just edit the learning note directly.
- Add delete by id function `zsh-learn-DeleteId` (aliased to `delid`) to delete a specific id in the table.