### PR TITLE
Show error when learning is greater than max size limit

### DIFF
--- a/autoload/zsh-learn-Editl
+++ b/autoload/zsh-learn-Editl
@@ -22,6 +22,11 @@ function zsh-learn-Editl(){
         return 1
     fi
 
+    if (( ${#learning} > $ZPWR_LEARN_MAX_SIZE )); then
+        echo "Learning is greater than limit of $ZPWR_LEARN_MAX_SIZE"
+        return 1
+    fi
+
     echo "UPDATE $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME SET learning='"$learning"' WHERE id = $1;" | ${=ZPWR_LEARN_COMMAND}
 }
 

--- a/autoload/zsh-learn-Savel
+++ b/autoload/zsh-learn-Savel
@@ -39,6 +39,11 @@ function zsh-learn-Savel(){
         return 1
     fi
 
+    if (( ${#learning} > $ZPWR_LEARN_MAX_SIZE )); then
+        echo "Learning is greater than limit of $ZPWR_LEARN_MAX_SIZE"
+        return 1
+    fi
+
     echo "insert into $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME (category, learning, dateAdded) values ('"$category"', '""$learning""', now())" | ${=ZPWR_LEARN_COMMAND} 2>> "$ZPWR_LOGFILE"
 }
 


### PR DESCRIPTION
Fixes issue of `le` and `editl` silently failing if entering a learning greater than the field length, defined by `$ZPWR_LEARN_MAX_SIZE`. Default length is 3000.