### PR TITLE
Escape single quotes before inserting

### DIFF
--- a/autoload/zsh-learn-Editl
+++ b/autoload/zsh-learn-Editl
@@ -27,6 +27,8 @@ function zsh-learn-Editl(){
         return 1
     fi
 
+    learning="$(echo $learning | sed 's@^[[:space:]]*@@;s@[[:space:]]*$@@;s/'\''/\\'\''/g')"
+
     echo "UPDATE $ZPWR_SCHEMA_NAME.$ZPWR_TABLE_NAME SET learning='"$learning"' WHERE id = $1;" | ${=ZPWR_LEARN_COMMAND}
 }
 

--- a/autoload/zsh-learn-Savel
+++ b/autoload/zsh-learn-Savel
@@ -31,13 +31,15 @@ function zsh-learn-Savel(){
     shift $(($OPTIND-1))
 
     if [[ -z $learning ]]; then
-        learning="$(printf -- '%s' "$1" | sed 's@^[[:space:]]*@@;s@[[:space:]]*$@@')"
+        learning="$(printf -- '%s' "$1")"
     fi
 
     if [[ -z $learning ]]; then
         usage
         return 1
     fi
+
+    learning="$(echo $learning | sed 's@^[[:space:]]*@@;s@[[:space:]]*$@@;s/'\''/\\'\''/g')"
 
     if (( $#learning > ZPWR_LEARN_MAX_SIZE )); then
         echo "Learning of size $#learning is greater than limit of $ZPWR_LEARN_MAX_SIZE"


### PR DESCRIPTION
Fixes issue where learnings that contain single quotes silently fail to insert due them causing syntax errors in SQL. This change escapes them with sed before inserting. Applies to save `le` and edit `editl` commands.